### PR TITLE
Minor fix to the pmApiRequest example

### DIFF
--- a/R/pmApiRequest.R
+++ b/R/pmApiRequest.R
@@ -24,8 +24,8 @@
 #' @examples
 #'
 #' \donttest{
-#' query <- query <- "bibliometric*[Title/Abstract] AND english[LA]
-#'                     AND Journal Article[PT] AND 2000:2020[DP]"
+#' query <- "bibliometric*[Title/Abstract] AND english[LA]
+#'           AND Journal Article[PT] AND 2000:2020[DP]"
 #'  D <- pmApiRequest(query = query, limit = 100, api_key = NULL)
 #' }
 #'

--- a/man/pmApiRequest.Rd
+++ b/man/pmApiRequest.Rd
@@ -37,8 +37,8 @@ Official API documentation is \href{https://www.ncbi.nlm.nih.gov/books/NBK25500/
 \examples{
 
 \donttest{
-query <- query <- "bibliometric*[Title/Abstract] AND english[LA]
-                    AND Journal Article[PT] AND 2000:2020[DP]"
+query <- "bibliometric*[Title/Abstract] AND english[LA]
+          AND Journal Article[PT] AND 2000:2020[DP]"
  D <- pmApiRequest(query = query, limit = 100, api_key = NULL)
 }
 


### PR DESCRIPTION
Thanks for a great package.

I noticed the query object was accidentally duplicated in the example on the `pmApiRequest()` help page.

This just deletes the duplication.